### PR TITLE
Added filter functionality

### DIFF
--- a/Source/analyser.c
+++ b/Source/analyser.c
@@ -177,6 +177,22 @@ static char        *Is_Tool(
 
             return ( s + 5 );
         }
+        /* Check if filter starts or ends */
+        if ( !strncmp( "filter ", s, 7 ) )
+        {
+            if ( *tool_active )
+            {
+                *itemkind = ITEM_LINE_FILTER_END;
+                *tool_active = 0;
+            }
+            else
+            {
+                *itemkind = ITEM_LINE_FILTER_START;
+                *tool_active = 1;
+            }
+
+            return ( s + 7 );
+        }
         /* Check if DOT starts or ends */
         if ( !strncmp( "dot ", s, 4 ) )
         {

--- a/Source/items.h
+++ b/Source/items.h
@@ -77,7 +77,9 @@ enum ItemLineKind
     ITEM_LINE_DOT_START,        /* Similar to TOOL_START but use DOT tool */
     ITEM_LINE_DOT_END,          /* End line of a DOT item */
     ITEM_LINE_DOT_FILE,         /* DOT file to include */
-    ITEM_LINE_INCLUDE           /* file to include */
+    ITEM_LINE_INCLUDE,          /* file to include */
+    ITEM_LINE_FILTER_START,     /* Similar to TOOL_START but use as a filter */
+    ITEM_LINE_FILTER_END        /* End of FILTER item */
 };
 
 /*****/


### PR DESCRIPTION
This PR introduces _"filter"_ functionality.  It similar to the _tool_ feature, but it will take the tool output
and embed it into the output documentation file in-place.

Example use:

```clang
/****m* tools/filtertest
 *
 * NAME
 *   FilterTest
 *
 * DESCRIPTION
 *   Example showing how to invoke external filter
 *
 * EXAMPLE
 * This one formats markdown input.  This requires a `markdown` command to exist:
 * The input data is passed through stdin.
 *
 * |filter markdown
 * This is markdown text:
 *
 * Use like *this* or __that__.
 * |filter end
*
* Using pandoc:
* 
* |filter pandoc -f csv -t %output_mode%
 * Country, Sales
 * Netherlands, 100
 * Belgium, 500
 * Luxemburg, 50
 * Total, 650
 * |filter end
 *
 ******
 */
```
To support multiple output formats, the `%output_mode%` is replaced to one of the following:

    ascii, latex, html, rtf, troff, xmldocbook, raw

So the filter can then arrange the output accordingly.  For example, a tool  like [pandoc](https://pandoc.org/index.html)
can be used to parse multiple mark-up formats and generate HTML, RTF, LaTeX, docbook, roff.

This means that a number of feature requests on the issues list could be implemented via external filter.  For example:

- #10 : I don't know Jade, but I imagine this could be done via a jade filter.
- #9 : This can be implemented trivially with using `cat` command as a filter.
- #8 : This could be done with pandoc or any user provided markdown converter

