### PR TITLE
Support the AIX plattforms

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -250,6 +250,16 @@ not '/usr/local'.  It is recommended to use the following options:
 
      ./configure --prefix=/boot/common
 
+   On AIX it is recommended to use the GNU Make. If the GNU CC is not
+installed the following options are used to work with the IBM XL C compiler:
+
+     ./configure CC="c99 -D_XOPEN_SOURCE" --prefix=/opt/freeware
+     gmake
+
+Not setting of _XOPEN_SOURCE is preventing compilation on AIX platforms.
+Additional software available to all users is mostly installed to
+'/opt/freeware' and not to '/usr/local'.
+
 Specifying the System Type
 ==========================
 

--- a/Source/troff_generator.c
+++ b/Source/troff_generator.c
@@ -30,7 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <ctype.h>
 
 #include <sys/param.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 
 #include "troff_generator.h"
 #include "util.h"


### PR DESCRIPTION
Based on the content of "sys/unistd.h" (in a Linux environment) I suggest to use "unistd.h" in "Source/troff_generator.c", like in "Source/document.c" or "Source/robodoc.c", "Source/robohdrs.c".

The "sys/unistd.h" is not available on AIX and MacOS plattforms, but "unistd.h" is.

I add some additional build information for AIX plattforms also.

See the issues #22 and #25 too.