### PR TITLE
Fix encoding of ChangeLog to be ISO 8859-1 again

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -118,7 +118,7 @@ Sep 2006
   o Corrected return value of main()
 
 Sep 2006 - V4.99.28
-  Michï¿½le Garoche
+  Michèle Garoche
   o Improved Mac support (for FINK)
 
 Aug 2006 - V4.99.28


### PR DESCRIPTION
Commit 54e703c872ec38e9d504fc75730133785699fb5e mangled the name of Michèle Garoche; this change restores the original encoding.